### PR TITLE
Feature/issue 164 event list

### DIFF
--- a/app/src/components/shared/EventListItem.svelte
+++ b/app/src/components/shared/EventListItem.svelte
@@ -20,6 +20,6 @@
   </div>
   <div class="flex flex-row items-center justify-between gap-6 pt-4 md:pt-0">
     <EventLogos {event} height={5} />
-    <ArrowRight class="mr-2" />
+    <ArrowRight class="mr-2 w-5 h-5 shrink-0" />
   </div>
 </a>

--- a/app/src/components/shared/EventListItem.svelte
+++ b/app/src/components/shared/EventListItem.svelte
@@ -8,18 +8,23 @@
 </script>
 
 <a
-  class="flex flex-col justify-between rounded-md px-3 py-4 hover:transition-[3s] border border-gray-200 hover:border-gray-800 dark:border-zinc-800
-  dark:bg-zinc-800 dark:hover:bg-zinc-700 md:flex-row"
+  class="flex flex-wrap md:flex-nowrap items-center rounded-md px-3 py-4 border border-gray-200
+  hover:border-gray-800 dark:border-zinc-800 dark:bg-zinc-800 dark:hover:bg-zinc-700"
   href={`/event/${event._id}`}
+  style="gap: 4px;"
 >
-  <div class="flex flex-col gap-3 px-0 font-light md:flex-row lg:gap-2 lg:px-2">
-    <h2 class="max-w-md truncate whitespace-pre-wrap pr-3 text-xl">
+  <div class="md:w-[45%] mr-1">
+    <h2 class="max-w-full truncate whitespace-pre-wrap text-xl">
       {event.title}
     </h2>
+  </div>
+  <div class="md:w-[30%] mr-1">
     <EventBadges {event} />
   </div>
-  <div class="flex flex-row items-center justify-between gap-6 pt-4 md:pt-0">
+  <div class="md:w-[20%] mr-1">
     <EventLogos {event} height={5} />
-    <ArrowRight class="mr-2 w-5 h-5 shrink-0" />
+  </div>
+  <div class="w-auto ml-auto flex-shrink-0 flex items-center justify-end">
+    <ArrowRight class="w-5 h-5" />
   </div>
 </a>

--- a/app/src/components/shared/EventLogos.svelte
+++ b/app/src/components/shared/EventLogos.svelte
@@ -11,8 +11,8 @@
   export let height: number;
 </script>
 
-<div class="flex items-center gap-4">
-  {#if event.organisers === "Alle"}
+<div class="flex flex-wrap items-center gap-4">
+{#if event.organisers === "Alle"}
     <img class="block h-{height} dark:hidden" alt="Capra-logo" src={capraLogoBlack} />
     <img class="hidden h-{height} dark:block" alt="Capra-logo" src={capraLogoWhite} />
     <img class="block h-{height} dark:hidden" alt="Liflig-logo" src={lifligLogoBlack} />


### PR DESCRIPTION
Issue https://github.com/capraconsulting/skjer/issues/164

Elementene i Event item har fått faste (%) bredder slik at de kommer rett over hverandre i desktop modus, og så wrappes de når skjermbredde kommer under en viss bredde (md)

Elementene i EventLogs wrappes også, slik at de ikke overskriver høyrepila på veldig små skjermer (bredde)