### PR TITLE
Lagt til meta-tagger i +page.svelte

### DIFF
--- a/app/src/lib/sanity/image.ts
+++ b/app/src/lib/sanity/image.ts
@@ -1,9 +1,8 @@
 import imageUrlBuilder from "@sanity/image-url";
 import { client } from "$lib/sanity/client";
-import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
 
 const builder = imageUrlBuilder(client);
 
-export function urlFor(source: SanityImageSource) {
+export function urlFor(source: string) {
   return builder.image(source).auto("format");
 }

--- a/app/src/routes/event/[id]/+page.server.ts
+++ b/app/src/routes/event/[id]/+page.server.ts
@@ -24,12 +24,13 @@ import {
   submitUnregistrationExternal,
 } from "$lib/actions/external/action";
 import { eventQuery as query } from "$lib/server/sanity/queries";
+import { sanityClientWithoutStega } from "$lib/server/sanity/client";
 
 export const load: PageServerLoad = async ({ params: { id }, locals }) => {
   const params = { id };
   const auth = await locals.auth();
 
-  const initial = await locals.loadQuery<Event>(query, params);
+  const initial = { data: await sanityClientWithoutStega.fetch<Event>(query, params) };
   const numberOfParticipants = await getNumberOfParticipants({ document_id: id });
 
   if (auth?.user?.name && auth.user.email) {

--- a/app/src/routes/event/[id]/+page.svelte
+++ b/app/src/routes/event/[id]/+page.svelte
@@ -1,35 +1,79 @@
+
 <script lang="ts">
-  import { useQuery } from "@sanity/svelte-loader";
   import EventFormExternal from "$components/external/EventFormExternal.svelte";
   import EventFormInternal from "$components/internal/EventFormInternal.svelte";
   import EventSummary from "$components/shared/EventSummary.svelte";
   import { ArrowLeft } from "phosphor-svelte";
+  import { urlFor } from "$lib/sanity/image";
+  import type { Event } from "$models/sanity.model";
 
-  export let data;
+  type PageData = {
+    options: {
+      initial: {
+        data: Event;
+      };
+    };
+    query: string;
+    params: { id: string };
+    registrationForm: unknown;
+    unregistrationForm: unknown;
+    numberOfParticipants: number;
+    isAttending?: boolean;
+    internalParticipantNames?: string[];
+  };
 
-  const { query, options, auth, params } = data;
+  export let data: PageData;
 
-  const result = useQuery({ query, options, params });
-
-  $: ({ data: event } = $result);
+  $: event = data.options.initial.data;
+  $: {
+    console.log('Event data:', event);
+    console.log('Title raw:', event?.title);
+    console.log('Summary raw:', event?.summary);
+  }
+  $: title = event?.title || 'Ikke funnet | Capra Liflig Fryde';
+  $: description = event?.summary || '';
 </script>
-
 <svelte:head>
-  <title>{event?.title || "Ikke funnet"} | Capra Liflig Fryde</title>
+  <title>{title}</title>
+  {#if event}
+    <meta name="description" content={description}/>
+
+    <!-- OpenGraph -->
+    <meta property="og:title" content={title}/>
+    <meta property="og:description" content={description}/>
+    <meta property="og:type" content="article"/>
+    {#if event.image?.asset?._ref}
+      {@const imageUrl = urlFor(event.image.asset._ref).url()}
+      {#if imageUrl}
+        <meta property="og:image" content={imageUrl}/>
+        <meta property="og:image:secure_url" content={imageUrl}/>
+        <meta property="og:image:alt" content={event.title}/>
+        <meta property="og:image:width" content="1200"/>
+        <meta property="og:image:height" content="630"/>
+
+        <!-- Twitter -->
+        <meta name="twitter:card" content="summary_large_image"/>
+        <meta name="twitter:site" content="@Capra"/>
+        <meta name="twitter:title" content={title}/>
+        <meta name="twitter:description" content={description}/>
+        <meta name="twitter:image" content={imageUrl}/>
+      {/if}
+    {/if}
+  {/if}
 </svelte:head>
 {#if event}
   <section>
     <div class="mb-9">
       <a class="flex items-center font-bold hover:underline" href="/">
-        <ArrowLeft weight="bold" class="mr-2 inline-flex" />
+        <ArrowLeft weight="bold" class="mr-2 inline-flex"/>
         <span>Alle arrangementer</span>
       </a>
     </div>
-    <EventSummary {event} {data} />
-    {#if auth?.user?.email && auth.user.name}
-      <EventFormInternal {event} {data} />
+    <EventSummary {event} {data}/>
+    {#if data.isAttending !== undefined && data.internalParticipantNames}
+    <EventFormInternal {event} {data}/>
     {:else}
-      <EventFormExternal {event} {data} />
+      <EventFormExternal {event} {data}/>
     {/if}
   </section>
 {:else}


### PR DESCRIPTION
Gjenbruker urlFor() fra image.ts, slakket litt på input-type slik at vi kan gi med string og ikke bare SanityImageSource (som = string)

Det blir masse garbage post-fixet på alle tekster (title, description etc), det er trolig Stega" (visual editing metadata) fra Sanity. Det synes ikke i UI siden det er usynlige kontrolltegn, men det synes i HTML og meta-tagger. Hvis vi endrer "load()" i +page.server.ts til å bruke sanityClientWithoutStega.fetch i stedet for `locals.loadQuery` så ser det mye bedre ut.