### PR TITLE
Ny filtreringsfunksjonalitet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 /.idea
+.aider.*

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "NODE_OPTIONS=--max-old-space-size=16384 vite build",
     "preview": "vite preview",
     "lint": "eslint 'src/**/*.{js,ts,svelte}'",
     "format": "prettier . --write .",

--- a/app/src/components/shared/EventFilter.svelte
+++ b/app/src/components/shared/EventFilter.svelte
@@ -1,47 +1,60 @@
 <script lang="ts">
   import { Button, ButtonGroup } from "flowbite-svelte";
-  import { createEventDispatcher } from "svelte";
-  import type { Category } from "$models/sanity.model";
   import { goto } from "$app/navigation";
+  import type { FilterType, FilterKey, FilterData } from '$lib/types/filter';
+ 
+  export let activeFilters;
+  export let deltakerFilter: FilterData;
+  export let kategoriFilter: FilterData;
 
-  export let selectedFilter: string;
-
-  const dispatch = createEventDispatcher();
   const searchParams = new URLSearchParams();
 
-  type Filters = { keyword: string; title: Category | "Alle" | "For alle" | "Kun interne" }[];
-  const filter: Filters = [
-    { title: "Alle", keyword: "" },
-    { title: "For alle", keyword: "for-alle" },
-    { title: "Kun interne", keyword: "kun-interne" },
-    { title: "Fag", keyword: "fag" },
-    { title: "Sosialt", keyword: "sosialt" },
-  ];
-
-  const handleFilterChange = async (filter: string) => {
-    dispatch("filterChange", filter);
+  const handleFilterChange = async (filter: FilterKey, searchParam: FilterType) => {
 
     if (filter) {
-      searchParams.set("filter", filter);
+      if (searchParams.has(searchParam) && filter === searchParams.get(searchParam)){
+        searchParams.delete(searchParam)
+      } else {
+        searchParams.set(searchParam, filter);
+      }
     } else {
-      searchParams.delete("filter");
+      searchParams.delete(searchParam);
     }
 
     await goto(`?${searchParams.toString()}`, { noScroll: true });
   };
+
 </script>
 
-<ButtonGroup class="flex-row flex-wrap gap-2 shadow-none md:justify-end md:self-end">
-  {#each filter as { title, keyword }}
-    <Button
-      on:click={() => handleFilterChange(keyword)}
-      class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
-        selectedFilter === keyword
-          ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
-          : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
-      }`}
-    >
-      {title}
-    </Button>
-  {/each}
-</ButtonGroup>
+<header>
+  <ButtonGroup class="flex-row flex-wrap gap-2 shadow-none md:justify-end md:self-end">
+    {#each deltakerFilter.list as { title, keyword }}
+      <Button
+        on:click={() => handleFilterChange(keyword, deltakerFilter.name)}
+        class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
+          Object.values(activeFilters).includes(keyword)
+            ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
+            : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
+        }`}
+      >
+        {title}
+      </Button>
+    {/each}
+  </ButtonGroup>
+  <span>|</span>
+  <ButtonGroup class="flex-row flex-wrap gap-2 shadow-none md:justify-end md:self-end">
+    {#each kategoriFilter.list as { title, keyword }}
+      <Button
+        on:click={() => handleFilterChange(keyword, kategoriFilter.name)}
+        class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
+          Object.values(activeFilters).includes(keyword)
+            ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
+            : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
+        }`}
+      >
+        {title}
+      </Button>
+    {/each}
+  </ButtonGroup>
+</header>
+

--- a/app/src/components/shared/EventFilter.svelte
+++ b/app/src/components/shared/EventFilter.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Button, ButtonGroup } from "flowbite-svelte";
   import { goto } from "$app/navigation";
-  import type { FilterType, FilterKey, FilterData } from '$lib/types/filter';
+  import type { FilterType, FilterKey, FilterData } from '$lib/types/filters.type';
  
   export let activeFilters;
   export let deltakerFilter: FilterData;
@@ -26,35 +26,39 @@
 
 </script>
 
-<header class="space-y-4">
+<menu class="space-y-4 flex-wrap">
   <ButtonGroup class="flex-row flex-wrap gap-2 shadow-none md:justify-end md:self-end">
     {#each deltakerFilter.list as { title, keyword }}
-      <Button
-        on:click={() => handleFilterChange(keyword, deltakerFilter.name)}
-        class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
-          Object.values(activeFilters).includes(keyword)
-            ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
-            : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
-        }`}
-      >
-        {title}
-      </Button>
+      <li>
+        <Button
+          on:click={() => handleFilterChange(keyword, deltakerFilter.name)}
+          class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
+            Object.values(activeFilters).includes(keyword)
+              ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
+              : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
+          }`}
+        >
+          {title}
+        </Button>
+      </li>
     {/each}
   </ButtonGroup>
-  <span>|</span>
+  <span id="vertical-divider">|</span>
   <ButtonGroup class="flex-row flex-wrap gap-2 shadow-none md:justify-end md:self-end">
     {#each kategoriFilter.list as { title, keyword }}
-      <Button
-        on:click={() => handleFilterChange(keyword, kategoriFilter.name)}
-        class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
-          Object.values(activeFilters).includes(keyword)
-            ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
-            : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
-        }`}
-      >
-        {title}
-      </Button>
+      <li>
+        <Button
+          on:click={() => handleFilterChange(keyword, kategoriFilter.name)}
+          class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
+            Object.values(activeFilters).includes(keyword)
+              ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
+              : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
+          }`}
+        >
+          {title}
+        </Button>
+      </li>
     {/each}
   </ButtonGroup>
-</header>
+</menu>
 

--- a/app/src/components/shared/EventFilter.svelte
+++ b/app/src/components/shared/EventFilter.svelte
@@ -26,7 +26,7 @@
 
 </script>
 
-<header>
+<header class="space-y-4">
   <ButtonGroup class="flex-row flex-wrap gap-2 shadow-none md:justify-end md:self-end">
     {#each deltakerFilter.list as { title, keyword }}
       <Button

--- a/app/src/components/shared/EventFilter.svelte
+++ b/app/src/components/shared/EventFilter.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
   import { Button, ButtonGroup } from "flowbite-svelte";
   import { goto } from "$app/navigation";
-  import type { FilterType, FilterKey, FilterData } from '$lib/types/filters.type';
- 
+  import type { FilterCategory, FilterKey, FilterData } from '$lib/types/filters.type';
+
   export let activeFilters;
   export let deltakerFilter: FilterData;
   export let kategoriFilter: FilterData;
 
   const searchParams = new URLSearchParams();
 
-  const handleFilterChange = async (filter: FilterKey, searchParam: FilterType) => {
+  const handleFilterChange = async (filter: FilterKey, searchParam: FilterCategory) => {
 
     if (filter) {
       if (searchParams.has(searchParam) && filter === searchParams.get(searchParam)){
-        searchParams.delete(searchParam)
+        searchParams.delete(searchParam);
       } else {
         searchParams.set(searchParam, filter);
       }
@@ -26,39 +26,44 @@
 
 </script>
 
+
 <menu class="space-y-4 flex-wrap">
-  <ButtonGroup class="flex-row flex-wrap gap-2 shadow-none md:justify-end md:self-end">
-    {#each deltakerFilter.list as { title, keyword }}
-      <li>
-        <Button
-          on:click={() => handleFilterChange(keyword, deltakerFilter.name)}
-          class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
-            Object.values(activeFilters).includes(keyword)
-              ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
-              : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
-          }`}
-        >
-          {title}
-        </Button>
-      </li>
-    {/each}
-  </ButtonGroup>
-  <span id="vertical-divider">|</span>
-  <ButtonGroup class="flex-row flex-wrap gap-2 shadow-none md:justify-end md:self-end">
-    {#each kategoriFilter.list as { title, keyword }}
-      <li>
-        <Button
-          on:click={() => handleFilterChange(keyword, kategoriFilter.name)}
-          class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
-            Object.values(activeFilters).includes(keyword)
-              ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
-              : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
-          }`}
-        >
-          {title}
-        </Button>
-      </li>
-    {/each}
-  </ButtonGroup>
+ <div class="flex flex-col lg:flex-row lg:items-center gap-2 w-fit">
+   <ButtonGroup class="flex-row flex-wrap gap-2 shadow-none lg:justify-end lg:self-end">
+     {#each deltakerFilter.list as { title, keyword }}
+       <li>
+         <Button
+           on:click={() => handleFilterChange(keyword, deltakerFilter.name)}
+           class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
+             Object.values(activeFilters).includes(keyword)
+               ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
+               : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
+           }`}
+         >
+           {title}
+         </Button>
+       </li>
+     {/each}
+   </ButtonGroup>
+
+   <div class="w-full lg:w-px h-px lg:h-8 bg-gray-300 lg:self-center dark:bg-gray-600"></div>
+
+   <ButtonGroup class="flex-row flex-wrap gap-2 shadow-none lg:justify-end lg:self-end">
+     {#each kategoriFilter.list as { title, keyword }}
+       <li>
+         <Button
+           on:click={() => handleFilterChange(keyword, kategoriFilter.name)}
+           class={`basis-1/4 whitespace-nowrap sm:basis-auto ${
+             Object.values(activeFilters).includes(keyword)
+               ? "h-8 !rounded-lg !border-zinc-800 bg-zinc-800 text-white hover:bg-zinc-800 dark:bg-zinc-600 dark:hover:bg-zinc-600"
+               : "h-8 !rounded-lg border border-[#999] hover:border-black hover:bg-white dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
+           }`}
+         >
+           {title}
+         </Button>
+       </li>
+     {/each}
+   </ButtonGroup>
+ </div>
 </menu>
 

--- a/app/src/components/shared/EventListItem.svelte
+++ b/app/src/components/shared/EventListItem.svelte
@@ -8,20 +8,24 @@
   export let target: string | null = null;
 </script>
 
-<a
-  class="flex flex-col justify-between gap-3 rounded-md border border-gray-200 px-3 py-4 hover:border-gray-800 hover:transition-[3s] md:flex-row
-  dark:border-zinc-800 dark:bg-zinc-800 dark:hover:bg-zinc-700"
-  href={`/event/${event._id}`}
-  {target}
->
-  <div class="flex flex-col gap-4 font-light lg:flex-row">
-    <h2 class="max-w-[375px] truncate whitespace-pre-wrap text-xl font-light">
-      {event.title}
-    </h2>
-    <EventBadges {event} />
-  </div>
-  <div class="flex flex-row items-end justify-between gap-4 pt-3 md:pt-0 lg:items-center">
-    <EventLogos {event} height={5} />
-    <ArrowRight class="mr-2" />
-  </div>
-</a>
+<li role="listitem">
+  
+  <a
+    class="flex flex-col justify-between gap-3 rounded-md border border-gray-200 px-3 py-4 hover:border-gray-800 hover:transition-[3s] md:flex-row
+    dark:border-zinc-800 dark:bg-zinc-800 dark:hover:bg-zinc-700"
+    href={`/event/${event._id}`}
+    {target}
+  >
+    <div class="flex flex-col gap-4 font-light lg:flex-row" >
+      <h2 class="max-w-[375px] truncate whitespace-pre-wrap text-xl font-light">
+        {event.title}
+      </h2>
+      <EventBadges {event} />
+    </div>
+    <div class="flex flex-row items-end justify-between gap-4 pt-3 md:pt-0 lg:items-center">
+      <EventLogos {event} height={5} />
+      <ArrowRight class="mr-2" />
+    </div>
+  </a>
+
+</li>

--- a/app/src/lib/types/filter.ts
+++ b/app/src/lib/types/filter.ts
@@ -1,0 +1,26 @@
+
+import type { Category } from "$models/sanity.model";
+export const VALID_PARTICIPANT_FILTER_KEYS = ['kun-interne', 'for-alle'] as const;
+
+// WARNING: This is defined in Sanity! See "Category" model above.
+export const VALID_EVENT_CATEGORY_FILTER_KEYS = ["fag", "sosialt"] as const;
+
+export const VALID_FILTERS = {
+  deltakerType: VALID_PARTICIPANT_FILTER_KEYS,
+  eventKategori: VALID_EVENT_CATEGORY_FILTER_KEYS,
+} as const;
+
+
+export type Filter = typeof VALID_FILTERS;
+export type FilterType = keyof typeof VALID_FILTERS;
+export type FilterKey = ParticipantFilterKey | EventCategoryFilterKey;
+export type ParticipantFilterKey = typeof VALID_PARTICIPANT_FILTER_KEYS[number];
+export type EventCategoryFilterKey = typeof VALID_EVENT_CATEGORY_FILTER_KEYS[number];
+
+export type EventFilter = { title: string, keyword: FilterKey };
+
+export type FilterData = { name: FilterType, list: EventFilter[] }
+
+export const isFilterKey = (s: string | FilterKey): s is FilterKey => {
+  return VALID_EVENT_CATEGORY_FILTER_KEYS.includes(s as EventCategoryFilterKey) || VALID_PARTICIPANT_FILTER_KEYS.includes(s as ParticipantFilterKey);
+}

--- a/app/src/lib/types/filters.type.ts
+++ b/app/src/lib/types/filters.type.ts
@@ -10,7 +10,6 @@ export const VALID_FILTERS = {
   eventKategori: VALID_EVENT_CATEGORY_FILTER_KEYS,
 } as const;
 
-
 export type Filter = typeof VALID_FILTERS;
 export type FilterType = keyof typeof VALID_FILTERS;
 export type FilterKey = ParticipantFilterKey | EventCategoryFilterKey;
@@ -23,4 +22,10 @@ export type FilterData = { name: FilterType, list: EventFilter[] }
 
 export const isFilterKey = (s: string | FilterKey): s is FilterKey => {
   return VALID_EVENT_CATEGORY_FILTER_KEYS.includes(s as EventCategoryFilterKey) || VALID_PARTICIPANT_FILTER_KEYS.includes(s as ParticipantFilterKey);
+}
+
+// This ensures type safety of Active Filters, and consistency in naming of url search params across client and server.
+// We cannot however guarantee that the values are set to a valid FilterKey (urls in browser can be edited directly of course), so we assume a string and work our way in from there.
+export type ActiveFilterFromURL = {
+  [k in FilterType]: string;
 }

--- a/app/src/lib/types/filters.type.ts
+++ b/app/src/lib/types/filters.type.ts
@@ -1,6 +1,5 @@
-
-import type { Category } from "$models/sanity.model";
-export const VALID_PARTICIPANT_FILTER_KEYS = ['kun-interne', 'for-alle'] as const;
+//import type { Category } from "$models/sanity.model";
+export const VALID_PARTICIPANT_FILTER_KEYS = ["kun-interne", "for-alle"] as const;
 
 // WARNING: This is defined in Sanity! See "Category" model above.
 export const VALID_EVENT_CATEGORY_FILTER_KEYS = ["fag", "sosialt"] as const;
@@ -10,22 +9,28 @@ export const VALID_FILTERS = {
   eventKategori: VALID_EVENT_CATEGORY_FILTER_KEYS,
 } as const;
 
+/// A Filter represents a set of filters (url search params) and their associated url parameter values
 export type Filter = typeof VALID_FILTERS;
-export type FilterType = keyof typeof VALID_FILTERS;
+/// A FilterCategory represents the set of valid URL Search Params
+export type FilterCategory = keyof typeof VALID_FILTERS;
 export type FilterKey = ParticipantFilterKey | EventCategoryFilterKey;
-export type ParticipantFilterKey = typeof VALID_PARTICIPANT_FILTER_KEYS[number];
-export type EventCategoryFilterKey = typeof VALID_EVENT_CATEGORY_FILTER_KEYS[number];
+export type ParticipantFilterKey = (typeof VALID_PARTICIPANT_FILTER_KEYS)[number];
+export type EventCategoryFilterKey = (typeof VALID_EVENT_CATEGORY_FILTER_KEYS)[number];
 
-export type EventFilter = { title: string, keyword: FilterKey };
+export type EventFilter = { title: string; keyword: FilterKey };
 
-export type FilterData = { name: FilterType, list: EventFilter[] }
+export type FilterData = { name: FilterCategory; list: EventFilter[] };
 
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export const isFilterKey = (s: string | FilterKey): s is FilterKey => {
-  return VALID_EVENT_CATEGORY_FILTER_KEYS.includes(s as EventCategoryFilterKey) || VALID_PARTICIPANT_FILTER_KEYS.includes(s as ParticipantFilterKey);
-}
+  return (
+    VALID_EVENT_CATEGORY_FILTER_KEYS.includes(s as EventCategoryFilterKey) ||
+    VALID_PARTICIPANT_FILTER_KEYS.includes(s as ParticipantFilterKey)
+  );
+};
 
-// This ensures type safety of Active Filters, and consistency in naming of url search params across client and server.
+// This seeks type safety of Active Filters, and consistency in naming of url search params across client and server.
 // We cannot however guarantee that the values are set to a valid FilterKey (urls in browser can be edited directly of course), so we assume a string and work our way in from there.
 export type ActiveFilterFromURL = {
-  [k in FilterType]: string;
-}
+  [k in FilterCategory]: string;
+};

--- a/app/src/lib/utils/filters.ts
+++ b/app/src/lib/utils/filters.ts
@@ -1,42 +1,45 @@
 import type { Event } from "$models/sanity.model";
-import type { FilterType, VALID_FILTERS, ActiveFilterFromURL } from "$lib/types/filters.type";
+import type { FilterCategory, VALID_FILTERS, ActiveFilterFromURL } from "$lib/types/filters.type";
 
-const FILTERING_LOGIC: FilterMatcherType = {
+const FILTERING_LOGIC: FilteringFunction = {
   deltakerType: {
     "for-alle": (eventToFilter: Event) => eventToFilter.openForExternals,
     "kun-interne": (eventToFilter: Event) => !eventToFilter.openForExternals,
   },
   eventKategori: {
-    "fag": (eventToFilter: Event) => eventToFilter.category?.toLowerCase() === 'fag',
-    "sosialt": (eventToFilter: Event) => eventToFilter.category?.toLowerCase() === 'sosialt',
-  }
+    fag: (eventToFilter: Event) => eventToFilter.category?.toLowerCase() === "fag",
+    sosialt: (eventToFilter: Event) => eventToFilter.category?.toLowerCase() === "sosialt",
+  },
 } as const;
 
 /**
-Applies the filters in activeFilters to events. Internally uses a matcher object containting filter logic for each valid key/value pair of the URL search params
+Applies the filters in activeFilters to events. Internally uses a object containting filter functions for each valid key/value pair of the URL search params
 **/
 export const applyFilters = (events: Event[], activeFilters: ActiveFilterFromURL): Event[] => {
   return events.filter((event) => {
     if (activeFilters.deltakerType) {
-      const filterFunction = FILTERING_LOGIC.deltakerType[activeFilters.deltakerType as keyof typeof FILTERING_LOGIC.deltakerType];
-      if (filterFunction && !(filterFunction(event))) return false; 
+      const filterFunction =
+        FILTERING_LOGIC.deltakerType[
+          activeFilters.deltakerType as keyof typeof FILTERING_LOGIC.deltakerType
+        ];
+      if (filterFunction && !filterFunction(event)) return false;
     }
 
     if (activeFilters.eventKategori) {
-      const filterFunction = FILTERING_LOGIC.eventKategori[activeFilters.eventKategori as keyof typeof FILTERING_LOGIC.eventKategori];
-      if (filterFunction && !(filterFunction(event))) return false; 
+      const filterFunction =
+        FILTERING_LOGIC.eventKategori[
+          activeFilters.eventKategori as keyof typeof FILTERING_LOGIC.eventKategori
+        ];
+      if (filterFunction && !filterFunction(event)) return false;
     }
 
     return true;
   });
-}
+};
 
-// Ensures correct implementation of the filter matcher object above.
-type FilterMatcherType = {
-  [key in FilterType]: {
-    [k in typeof VALID_FILTERS[key][number]]: (eventToFilter: Event) => boolean; 
-  }
-}
-
-
-
+// Ensures correct implementation of the filter function object above.
+type FilteringFunction = {
+  [key in FilterCategory]: {
+    [k in (typeof VALID_FILTERS)[key][number]]: (eventToFilter: Event) => boolean;
+  };
+};

--- a/app/src/lib/utils/filters.ts
+++ b/app/src/lib/utils/filters.ts
@@ -1,0 +1,42 @@
+import type { Event } from "$models/sanity.model";
+import type { FilterType, VALID_FILTERS, ActiveFilterFromURL } from "$lib/types/filters.type";
+
+const FILTERING_LOGIC: FilterMatcherType = {
+  deltakerType: {
+    "for-alle": (eventToFilter: Event) => eventToFilter.openForExternals,
+    "kun-interne": (eventToFilter: Event) => !eventToFilter.openForExternals,
+  },
+  eventKategori: {
+    "fag": (eventToFilter: Event) => eventToFilter.category?.toLowerCase() === 'fag',
+    "sosialt": (eventToFilter: Event) => eventToFilter.category?.toLowerCase() === 'sosialt',
+  }
+} as const;
+
+/**
+Applies the filters in activeFilters to events. Internally uses a matcher object containting filter logic for each valid key/value pair of the URL search params
+**/
+export const applyFilters = (events: Event[], activeFilters: ActiveFilterFromURL): Event[] => {
+  return events.filter((event) => {
+    if (activeFilters.deltakerType) {
+      const filterFunction = FILTERING_LOGIC.deltakerType[activeFilters.deltakerType as keyof typeof FILTERING_LOGIC.deltakerType];
+      if (filterFunction && !(filterFunction(event))) return false; 
+    }
+
+    if (activeFilters.eventKategori) {
+      const filterFunction = FILTERING_LOGIC.eventKategori[activeFilters.eventKategori as keyof typeof FILTERING_LOGIC.eventKategori];
+      if (filterFunction && !(filterFunction(event))) return false; 
+    }
+
+    return true;
+  });
+}
+
+// Ensures correct implementation of the filter matcher object above.
+type FilterMatcherType = {
+  [key in FilterType]: {
+    [k in typeof VALID_FILTERS[key][number]]: (eventToFilter: Event) => boolean; 
+  }
+}
+
+
+

--- a/app/src/routes/+page.server.ts
+++ b/app/src/routes/+page.server.ts
@@ -13,7 +13,7 @@ import type { EventFilter, FilterData } from "$lib/types/filters.type";
 We define the list of filters and their display info here, and it will be sent to frontend.
 */
 const deltakerTypeFilterList: EventFilter[] = [{ title: "Kun interne", keyword: "kun-interne" }, { title: "Åpent for alle", keyword: "for-alle" }];
-const eventKategoriFilterList: EventFilter[] = [{ title: "Fag", keyword: "fag"}, { title: "Sosialt", keyword: 'sosialt'}];
+const eventKategoriFilterList: EventFilter[] = [{ title: "#Fag", keyword: "fag"}, { title: "#Sosialt", keyword: 'sosialt'}];
 
 type AvailableFilterData = {
   participantFilters: FilterData,

--- a/app/src/routes/+page.server.ts
+++ b/app/src/routes/+page.server.ts
@@ -7,14 +7,11 @@ import {
 } from "$lib/server/sanity/queries";
 import { getParticipantAttendingEvents } from "$lib/server/supabase/queries";
 import type { EventWithAttending } from "$models/databaseView.model";
-import type { EventFilter, FilterData } from "$lib/types/filter";
-
-
+import type { EventFilter, FilterData } from "$lib/types/filters.type";
 
 /*
 We define the list of filters and their display info here, and it will be sent to frontend.
 */
-
 const deltakerTypeFilterList: EventFilter[] = [{ title: "Kun interne", keyword: "kun-interne" }, { title: "Åpent for alle", keyword: "for-alle" }];
 const eventKategoriFilterList: EventFilter[] = [{ title: "Fag", keyword: "fag"}, { title: "Sosialt", keyword: 'sosialt'}];
 
@@ -22,7 +19,6 @@ type AvailableFilterData = {
   participantFilters: FilterData,
   eventCategoryFilters: FilterData
 }
-
 
 // Sent to frontend to ensure consistency on url search params
 const filterGroups: AvailableFilterData = {
@@ -35,7 +31,6 @@ const filterGroups: AvailableFilterData = {
     list: eventKategoriFilterList,
   }
 };
-
 
 export const load: PageServerLoad = async ({ locals }) => {
   const auth = await locals.auth();

--- a/app/src/routes/+page.server.ts
+++ b/app/src/routes/+page.server.ts
@@ -7,11 +7,39 @@ import {
 } from "$lib/server/sanity/queries";
 import { getParticipantAttendingEvents } from "$lib/server/supabase/queries";
 import type { EventWithAttending } from "$models/databaseView.model";
+import type { EventFilter, FilterData } from "$lib/types/filter";
 
-export const load: PageServerLoad = async ({ url, locals }) => {
+
+
+/*
+We define the list of filters and their display info here, and it will be sent to frontend.
+*/
+
+const deltakerTypeFilterList: EventFilter[] = [{ title: "Kun interne", keyword: "kun-interne" }, { title: "Åpent for alle", keyword: "for-alle" }];
+const eventKategoriFilterList: EventFilter[] = [{ title: "Fag", keyword: "fag"}, { title: "Sosialt", keyword: 'sosialt'}];
+
+type AvailableFilterData = {
+  participantFilters: FilterData,
+  eventCategoryFilters: FilterData
+}
+
+
+// Sent to frontend to ensure consistency on url search params
+const filterGroups: AvailableFilterData = {
+  participantFilters: {
+    name: "deltakerType",
+    list: deltakerTypeFilterList,
+  },
+  eventCategoryFilters: {
+    name: "eventKategori",
+    list: eventKategoriFilterList,
+  }
+};
+
+
+export const load: PageServerLoad = async ({ locals }) => {
   const auth = await locals.auth();
-  const selectedFilter = url.searchParams.get("filter")?.toLowerCase() || "";
-
+  
   if (auth?.user?.email) {
     const futureEventsContent = await getFutureEvents();
 
@@ -28,7 +56,7 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     return {
       futureEvents,
       pastEvents,
-      selectedFilter,
+      filterGroups,
     };
   }
 
@@ -38,6 +66,6 @@ export const load: PageServerLoad = async ({ url, locals }) => {
   return {
     futureEvents,
     pastEvents,
-    selectedFilter,
+    filterGroups,
   };
 };

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -7,7 +7,7 @@
   import { page } from '$app/stores';
   import { goto } from "$app/navigation";
   import { browser } from "$app/environment";
-  import { applyFilters } from '$lib/utils/filters'
+  import { applyFilters } from '$lib/utils/filters';
   import { VALID_FILTERS, type ActiveFilterFromURL } from "$lib/types/filters.type";
 
   /*
@@ -20,9 +20,9 @@
     - lib/filters.ts contains helper functions for the filtering logic
 
   HOW FILTERS WORK
-  
+
   - All filter state is to be found in the URL, more specifically in the URL search params. When these change, so does the filtering of the list.
-  - We have filters, and we have filter groups, which filters belong to.
+  - For frontend logic we have filters, and we have filter groups, which filters belong to.
   - A filter group is a self-contained group of filter toggles that are mutually exclusive. If you toggle one of the filters in a group, the others in that group are toggled off.
     - Toggling on or off filters in one group will not affect those in other groups
   - In the EventFilter component, these filter groups are arranged into separate ButtonGroups.
@@ -30,13 +30,16 @@
   - Each click of a button (filter) will directly edit the URL search params client side, and then call goto(new url).
   - This page (containing the list of events) will conditionally render the list of events, based on these URL search parameters.
   - It will also continuously sanitize (remove unwanted) URL search params, quite simply because a server-side version of that sanitization using redirects I could not get to work. The current solution works fine.
+
+  POTENTIAL DOWNSIDES
+  - Continuosly re-render on each filter change. Though Svelte normally does a good job with avoiding the worst, most inefficient re-renders. It works for now.
   */
 
   export let data;
 
   let { pastEvents } = data;
 
-  // Shorthands for further down the line
+  // Aliases
   const participantFilterUrlParamName = data.filterGroups.participantFilters.name;
   const eventCategoryFilterUrlParamName = data.filterGroups.eventCategoryFilters.name;
 
@@ -50,44 +53,45 @@
     eventKategori: $page.url.searchParams.get(eventCategoryFilterUrlParamName) || '',
   };
 
+  $: filteredFutureEvents = applyFilters(data.futureEvents, activeFilters);
 
-  $: filteredFutureEvents = applyFilters(data.futureEvents, activeFilters)
-
-  // See below
-  $: removeInvalidSearchParamsAndNavigateIfNeeded();
+  // Run this function when search parameters change.
+  $: if ($page.url.searchParams) {
+      void (async () => await sanitizeSearchParamsAndNavigateIfNeeded())();
+  }
 
   /**
-  This function ensures that URL search parameters are valid. It does so by iterating through all valid filters, getting the current URL parameter value of that filter, and then checking to see if that value exists, and is valid.
+  This function ensures that URL search parameters - the selected filter categories - are valid. It does so by iterating through all valid filters, getting the current URL parameter value of that filter, and then checking to see if that value exists, and is valid.
   If it is not, it removes that parameter directly from the URL, and navigates to the new (remaining) URL.
   **/
-  const removeInvalidSearchParamsAndNavigateIfNeeded = () => {
+  const sanitizeSearchParamsAndNavigateIfNeeded = async () => {
 
     if(browser) {
       let hasInvalidFilter = false;
 
-      Object.entries(VALID_FILTERS).forEach(([filterType, validFilterKeys]) => {
-        const currentParam = $page.url.searchParams.get(filterType);
+      // Removes invalid search parameter values
+      Object.entries(VALID_FILTERS).forEach(([filterCategory, validFilterKeys]) => {
+        const currentParam = $page.url.searchParams.get(filterCategory);
         if(currentParam && !(validFilterKeys as readonly string[]).includes(currentParam)) {
-          $page.url.searchParams.delete(filterType);
+          $page.url.searchParams.delete(filterCategory);
           hasInvalidFilter = true;
         }
       });
 
-      // Removing invalid FilterTypes too, because why not
-      $page.url.searchParams.keys().forEach((supposedFilterType) => {
-        if(!Object.keys(VALID_FILTERS).includes(supposedFilterType)) {
-          $page.url.searchParams.delete(supposedFilterType);
+      // Removing invalid FilterCategory too, because why not
+      $page.url.searchParams.keys().forEach((supposedFilterCategory) => {
+        if(!Object.keys(VALID_FILTERS).includes(supposedFilterCategory)) {
+          $page.url.searchParams.delete(supposedFilterCategory);
           hasInvalidFilter = true;
         }
-      })
+      });
 
       if (hasInvalidFilter) {
-        goto($page.url, { replaceState: true } )
+        await goto($page.url, { replaceState: true } );
       }
-      
+
     }
-    
-  }
+  };
 </script>
 
 <svelte:head>
@@ -102,7 +106,7 @@
     <EventFilter {activeFilters} deltakerFilter={data.filterGroups.participantFilters} kategoriFilter={data.filterGroups.eventCategoryFilters} />
   </div>
 
-  <ol class="flex flex-col gap-4 pb-5" role="list">
+  <ol class="flex flex-col gap-6 pb-5" role="list">
     {#if filteredFutureEvents.length}
       {#each filteredFutureEvents.slice(0, amountOfVisibleFutureEvents) as event}
         <EventListItem {event} />

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -102,7 +102,7 @@
     <EventFilter {activeFilters} deltakerFilter={data.filterGroups.participantFilters} kategoriFilter={data.filterGroups.eventCategoryFilters} />
   </div>
 
-  <div class="flex flex-col gap-4 pb-5">
+  <ol class="flex flex-col gap-4 pb-5" role="list">
     {#if filteredFutureEvents.length}
       {#each filteredFutureEvents.slice(0, amountOfVisibleFutureEvents) as event}
         <EventListItem {event} />
@@ -118,7 +118,7 @@
     {:else}
       <div class="text-xl font-light">Fant ingen kommende arrangementer i denne kategorien 😭</div>
     {/if}
-  </div>
+  </ol>
 </section>
 
 <section class="pb-8">

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -4,26 +4,122 @@
   import EventCard from "$components/shared/EventCard.svelte";
   import EventListItem from "$components/shared/EventListItem.svelte";
   import EventFilter from "$components/shared/EventFilter.svelte";
+  import { page } from '$app/stores';
+  import { goto } from "$app/navigation";
+  import { browser } from "$app/environment";
+  import { VALID_FILTERS, type FilterType } from "$lib/types/filter.js";
+
+  /*
+  This effectively renders the event list on the landing page of Skjer.
+
+  Data is fetched from backend, naturally, but so is a whole bunch of information about valid filters, their groups, and their URL Search Param name.
+    - See lib/types/filter.ts for type definitions, and constants that are used in the filtering process.
+
+  HOW FILTERS WORK
+  
+  - All filter state is to be found in the URL, more specifically in the URL search params. When these change, so does the filtering of the list.
+  - We have filters, and we have filter groups, which filters belong to.
+  - A filter group is a self-contained group of filter toggles that are mutually exclusive. If you toggle one of the filters in a group, the others in that group are toggled off.
+    - Toggling on or off filters in one group will not affect those in other groups
+
+  
+  - In the EventFilter component, these filter groups are arranged into two separate ButtonGroups.
+  - Each filter is therefore rendered as a Button
+  - Each click of a button (filter) will directly edit the URL search params client side, and then call goto(new url).
+  - This page (containing the list of events) will conditionally render the list of events, based on these URL search parameters.
+  - It will also continuously sanitize (remove unwanted) URL search params, quite simply because a server-side version of that sanitization using redirects I could not get to work. The current solution works fine.
+  */
 
   export let data;
 
-  let { futureEvents, pastEvents, selectedFilter } = data;
+  let { futureEvents, pastEvents } = data;
+
+  // Shorthands for further down the line
+  const participantFilterUrlParamName = data.filterGroups.participantFilters.name;
+  const eventCategoryFilterUrlParamName = data.filterGroups.eventCategoryFilters.name;
 
   let amountOfVisibleFutureEvents = 6;
   let amountOfVisiblePastEvents = 6;
 
-  $: futureEventsFiltered = futureEvents.filter(({ category, openForExternals }) => {
-    if (!selectedFilter) {
-      return true;
-    }
-    if (selectedFilter === "kun-interne") {
-      return !openForExternals;
-    }
-    if (selectedFilter === "for-alle") {
-      return openForExternals;
-    }
-    return category?.toLowerCase() === selectedFilter;
+
+  // This ensures type safety in activeFilters, and consistency in naming of url search params across client and server.
+  // We cannot however guarantee that the values are set to a valid FilterKey (urls in browser can be edited directly of course), so we assume a string and work our way in from there.
+  // See removeInvalidSearchParamsAndRedirect() which continously ensures that the FilterKeys we end up with, are valid
+  type ActiveFilterFromURL = {
+    [k in FilterType]: string;
+  }
+
+  let activeFilters: ActiveFilterFromURL;
+
+  $: activeFilters = {
+    deltakerType: $page.url.searchParams.get(participantFilterUrlParamName) || '',
+    eventKategori: $page.url.searchParams.get(eventCategoryFilterUrlParamName) || '',
+  };
+
+
+  $: filteredFutureEvents = futureEvents.filter(({ category, openForExternals }) => {
+
+    // NOTE: Due to a lack of exhaustive matching support, please add to this list whenever new filters are added. Typescript will not tell you if you aren't handling a specific filter.
+    // Naturally, each filter group would be its own else if clause.
+    return Object.entries(activeFilters).every(([filterKey, filterValue]) => {
+      if (filterKey === participantFilterUrlParamName) {
+        switch (filterValue) {
+          case 'kun-interne':
+            return !openForExternals
+          case "for-alle":
+            return openForExternals
+        }
+      } else if (filterKey === eventCategoryFilterUrlParamName) {
+        switch (filterValue) {
+          case 'fag':
+            return category?.toLowerCase() === 'fag'
+          case 'sosialt':
+            return category?.toLowerCase() === 'sosialt'
+        }
+      }
+      return true
+       
+    })
+
   });
+
+  // See below
+  $: removeInvalidSearchParamsAndRedirect();
+
+  /**
+  This function ensures that URL search parameters are valid. It does so by iterating through all valid filters, and then checking to see if the value attached to that URL search parameter is valid.
+  If it is not, it removes that parameter directly from the URL, and redirects to the new (remaining) URL.
+  
+  We are doing this the hard way here in frontend, because redirect(30x, 'new url') server-side does not seem to work.
+  **/
+  const removeInvalidSearchParamsAndRedirect = () => {
+
+    if(browser) {
+      let hasInvalidFilter = false;
+
+      Object.entries(VALID_FILTERS).forEach(([filterType, validFilterKeys]) => {
+        const currentParam = $page.url.searchParams.get(filterType);
+        if(currentParam && !(validFilterKeys as readonly string[]).includes(currentParam)) {
+          $page.url.searchParams.delete(filterType);
+          hasInvalidFilter = true;
+        }
+      });
+
+      // Removing invalid FilterTypes too, because why not
+      $page.url.searchParams.keys().forEach((supposedFilterType) => {
+        if(!Object.keys(VALID_FILTERS).includes(supposedFilterType)) {
+          $page.url.searchParams.delete(supposedFilterType);
+          hasInvalidFilter = true;
+        }
+      })
+
+      if (hasInvalidFilter) {
+        goto($page.url, { replaceState: true } )
+      }
+      
+    }
+    
+  }
 </script>
 
 <svelte:head>
@@ -35,15 +131,15 @@
     <h1 class="text-4xl font-semibold md:text-5xl">
       Kommende<br />arrangementer
     </h1>
-    <EventFilter {selectedFilter} on:filterChange={({ detail }) => (selectedFilter = detail)} />
+    <EventFilter {activeFilters} deltakerFilter={data.filterGroups.participantFilters} kategoriFilter={data.filterGroups.eventCategoryFilters} />
   </div>
 
   <div class="flex flex-col gap-4 pb-5">
-    {#if futureEventsFiltered.length}
-      {#each futureEventsFiltered.slice(0, amountOfVisibleFutureEvents) as event}
+    {#if filteredFutureEvents.length}
+      {#each filteredFutureEvents.slice(0, amountOfVisibleFutureEvents) as event}
         <EventListItem {event} />
       {/each}
-      {#if futureEventsFiltered.length > amountOfVisibleFutureEvents}
+      {#if filteredFutureEvents.length > amountOfVisibleFutureEvents}
         <div class="mt-6 flex flex-wrap self-center">
           <Button pill color="alternative" on:click={() => (amountOfVisibleFutureEvents += 6)}>
             <span class="mr-2">Se flere arrangementer</span>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
Denne endringen er en overhaling av filterlogikken  i Skjer, samt litt diverse stæsj - blant annet en "divider" i EventFilter komponentet etter ønske fra Irene.

Hensikten er:

- Å støtte kombinerte filtre. Altså se _sosiale arrangementer_ som kun er åpent for _interne_, eller sosiale arrangementer som også er åpent for eksterne. Man kan også se alle arrangementer ved å skru av samtlige filtre.

## Filtre
Et filter kan være av eller på. Men den største endringen er at et filter nå er en del av en **filtergruppe**.

## Filtergrupper
Alle filtre innenfor en filtergruppe er gjensidig utelukkende.  Det vil si at dersom jeg skrur på et filter innenfor filtergruppe A, vil andre filtre innenfor samme gruppe, skrus av. Hvis jeg derimot skrur av et filter, vil ikke andre filtre skrus på. Ganske greit.

Endringer i en filtergruppe vil naturligvis ikke påvirke filtre i andre filtergrupper. Så dersom jeg skrur på "For interne" filteret i "deltakerType"-gruppen, vil jeg beholde eventuelle filtre fra "eventKategori"-gruppen .

_På den måte kan man kombinere filtre fra ulike grupper, og se eksempelvis faglige arrangementer for interne, eller faglige arrangementer som også er åpent for eksterne_. Eller rett og slett kun sosiale arrangementer, uten noe filter på deltakertype.

## Typesetting
Jeg har laget en filters.types.ts fil som inneholder en del typer. Dette egentlig fordi man da unngår skriveleifer og lar Typescript fanger filtre som ikke det er støtte for, osv. 

Dersom man i fremtiden ønsker å legge til flere filtre eller filtergrupper, blir det da nødvendig å begynne der.